### PR TITLE
Rename log1mexp in texmex

### DIFF
--- a/src/special_functions.cpp
+++ b/src/special_functions.cpp
@@ -24,7 +24,7 @@ Rcpp::NumericVector wrap_log1prel(const Rcpp::NumericVector& x) {
 //' @return a numeric vector
 // [[Rcpp::export(name=".log1mexp", rng=FALSE)]]
 Rcpp::NumericVector wrap_log1mexp(const Rcpp::NumericVector& x) {
-  return Rcpp::sapply(x, log1mexp);
+  return Rcpp::sapply(x, texmex_log1mexp);
 }
 
 //' Compute pmax(x y, -1) in such a way that zeros in x beat

--- a/src/special_functions.h
+++ b/src/special_functions.h
@@ -76,7 +76,7 @@ namespace {
   */
   
   inline
-  double log1mexp(const double x) {
+  double texmex_log1mexp(const double x) {
     /* accurately compute log(1-exp(x)) */
     if (R_FINITE(x)) {
       if (x > -M_LN2) {


### PR DESCRIPTION
R-devel now includes its own log1mexp, and (I *think*) this is causing confusion
and delay. Have renamed the texmex version for now.